### PR TITLE
Including Macbooks with Apple M1 Pro Chip

### DIFF
--- a/Formula/pomerium.rb
+++ b/Formula/pomerium.rb
@@ -8,13 +8,21 @@ class Pomerium < Formula
   version "0.17.1"
 
   on_macos do
-    if Hardware::CPU.intel?
+    if Hardware::CPU.arm?
       url "https://github.com/pomerium/pomerium/releases/download/v0.17.1/pomerium-darwin-amd64.tar.gz"
       sha256 "8b532da9ee7be955412208359d4cb89c810feffccc4ddb906d31c06364a11d01"
 
       def install
         bin.install "pomerium"
       end
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/pomerium/pomerium/releases/download/v0.17.1/pomerium-darwin-amd64.tar.gz"
+      sha256 "8b532da9ee7be955412208359d4cb89c810feffccc4ddb906d31c06364a11d01"
+
+        def install
+          bin.install "pomerium"
+        end
     end
   end
 


### PR DESCRIPTION
Running into issues when running `brew tap pomerium/tap` on my macbook pro with an apple chip

brew tap pomerium/tap    
==> Tapping pomerium/tap
Cloning into '/opt/homebrew/Library/Taps/pomerium/homebrew-tap'...
remote: Enumerating objects: 388, done.
remote: Counting objects: 100% (388/388), done.
remote: Compressing objects: 100% (374/374), done.
remote: Total 388 (delta 102), reused 4 (delta 0), pack-reused 0
Receiving objects: 100% (388/388), 55.61 KiB | 3.71 MiB/s, done.
Resolving deltas: 100% (102/102), done.
Error: Invalid formula: /opt/homebrew/Library/Taps/pomerium/homebrew-tap/Formula/pomerium.rb
formulae require at least a URL
Error: Cannot tap pomerium/tap: invalid syntax in tap!