### PR TITLE
Add arm arch for pomerium formula

### DIFF
--- a/Formula/pomerium.rb
+++ b/Formula/pomerium.rb
@@ -8,13 +8,21 @@ class Pomerium < Formula
   version "0.17.3"
 
   on_macos do
-    if Hardware::CPU.intel?
+    if Hardware::CPU.arm?
       url "https://github.com/pomerium/pomerium/releases/download/v0.17.3/pomerium-darwin-amd64.tar.gz"
       sha256 "90847de4e0287738244badc66a4072e48800b312a7b90ad9ebb37b8f48fd1ece"
 
       def install
         bin.install "pomerium"
       end
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/pomerium/pomerium/releases/download/v0.17.3/pomerium-darwin-amd64.tar.gz"
+      sha256 "90847de4e0287738244badc66a4072e48800b312a7b90ad9ebb37b8f48fd1ece"
+
+        def install
+          bin.install "pomerium"
+        end
     end
   end
 


### PR DESCRIPTION
Not sure if this is a good idea or not, but when you follow instructions on an ARM mac, it doesn't work.  Instead, you have to do something like this: 

```
➜  arch -x86_64 brew tap pomerium/tap
==> Tapping pomerium/tap
Cloning into '/opt/homebrew/Library/Taps/pomerium/homebrew-tap'...
remote: Enumerating objects: 436, done.
remote: Counting objects: 100% (31/31), done.
remote: Compressing objects: 100% (27/27), done.
remote: Total 436 (delta 17), reused 6 (delta 4), pack-reused 405
Receiving objects: 100% (436/436), 61.85 KiB | 1.47 MiB/s, done.
Resolving deltas: 100% (121/121), done.
Tapped 1 cask and 2 formulae (17 files, 83.4KB).
```

Then, confusingly, `pomerium-cli` has a darwin-arm64 binary, but `pomerium` itself does not, so one will require the same `arch` prefix, but the other won't.   

This PR will make it so that none of the commands require an arch prefix to work (good), but it is lying about there being a `darwin-arm64` build of `pomerium` (bad).

As a note, why is the darwin-arm64 build of pomerium specifically skipped? 
https://github.com/pomerium/pomerium/blob/main/.github/goreleaser.yaml#L31-L33

Thanks for your time and attention...