### PR TITLE
install intel pomerium on m1

### DIFF
--- a/Formula/pomerium.rb
+++ b/Formula/pomerium.rb
@@ -8,13 +8,11 @@ class Pomerium < Formula
   version "0.17.3"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/pomerium/pomerium/releases/download/v0.17.3/pomerium-darwin-amd64.tar.gz"
-      sha256 "90847de4e0287738244badc66a4072e48800b312a7b90ad9ebb37b8f48fd1ece"
+    url "https://github.com/pomerium/pomerium/releases/download/v0.17.3/pomerium-darwin-amd64.tar.gz"
+    sha256 "90847de4e0287738244badc66a4072e48800b312a7b90ad9ebb37b8f48fd1ece"
 
-      def install
-        bin.install "pomerium"
-      end
+    def install
+      bin.install "pomerium"
     end
   end
 


### PR DESCRIPTION
Install intel pomerium on m1. AFAIK it's not possible to build pomerium using github actions for macos m1. They don't have a runner for it. I have no idea if this will work. I wasn't able to figure out how to install a tap from a different branch so I just guessed.

- https://github.com/pomerium/cli/issues/86