### PR TITLE
use apparitor github token for desktop workflow

### DIFF
--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -1,3 +1,4 @@
+name: Update pomerium-desktop
 on:
   repository_dispatch:
     types: [desktop-client-release]
@@ -7,7 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
       - run: ./scripts/desktop-client-release
         env:
           VERSION: ${{ github.event.client_payload.version }}
       - uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842
+        with:
+          commit_message: "update pomerium-desktop cask for version v${{ github.event.client_payload.version }}"


### PR DESCRIPTION
Currently the desktop.yaml workflow is failing due to a repository rule requiring all changes to be made by a PR: https://github.com/pomerium/homebrew-tap/actions/runs/14388873911/job/40350894784. We should be able to use the apparitor github account instead, which has permissions to bypass this rule.

Also add a friendly name for this workflow, and update the generated commit message.