### PR TITLE
Revert "update pomerium-cli formula for version v0.0.1"

### DIFF
--- a/Formula/pomerium-cli.rb
+++ b/Formula/pomerium-cli.rb
@@ -1,20 +1,20 @@
 class PomeriumCli < Formula
   desc ""
   homepage "https://www.pomerium.com"
-  version "0.0.1"
+  version "0.29.1"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/pomerium/cli/releases/download/v0.0.1/pomerium-cli-darwin-amd64.tar.gz"
-      sha256 "fb629ad315c4fa46d28058718fdad304dfdf9431a31ccd8283e35654ec1b76bb"
+      url "https://github.com/pomerium/cli/releases/download/v0.29.1/pomerium-cli-darwin-amd64.tar.gz"
+      sha256 "339c6a96f1809585ee815bb38629dec4541498c1a4771e05fa1f0a5309f7004b"
 
       def install
         bin.install "pomerium-cli"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/pomerium/cli/releases/download/v0.0.1/pomerium-cli-darwin-arm64.tar.gz"
-      sha256 "eb58a12d66f67a25670ffd8314eca9fe9c8582e66a4eca6a50cb201a3f26da8a"
+      url "https://github.com/pomerium/cli/releases/download/v0.29.1/pomerium-cli-darwin-arm64.tar.gz"
+      sha256 "2dc649544b2f4a96fbcf2f60015bb40d554b601d174c90395d39a2117f831386"
 
       def install
         bin.install "pomerium-cli"
@@ -24,24 +24,24 @@ class PomeriumCli < Formula
 
   on_linux do
     if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://github.com/pomerium/cli/releases/download/v0.0.1/pomerium-cli-linux-armv6.tar.gz"
-      sha256 "9cc6b7cb43b8b2d041a8aa21cc225f28611bfa9e7e392121bc2917459d5324e3"
+      url "https://github.com/pomerium/cli/releases/download/v0.29.1/pomerium-cli-linux-armv6.tar.gz"
+      sha256 "aa3e3a71a4353e96820bce17d58922809d8ba9ac4293b2d7382ed48ace854921"
 
       def install
         bin.install "pomerium-cli"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/pomerium/cli/releases/download/v0.0.1/pomerium-cli-linux-arm64.tar.gz"
-      sha256 "6757cf43f1dd7bf5d725ad90d143eb29b0e262a7e0963c14c6c0f1b7abfbc127"
+      url "https://github.com/pomerium/cli/releases/download/v0.29.1/pomerium-cli-linux-arm64.tar.gz"
+      sha256 "9336aa614c0806403a768706cb3431347f4ebe66aae0cb9ade7edc0a58491827"
 
       def install
         bin.install "pomerium-cli"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/pomerium/cli/releases/download/v0.0.1/pomerium-cli-linux-amd64.tar.gz"
-      sha256 "04de26c0688e562d2ef77e73880b17ddab90fb121697c3614a71e063c80a6dfd"
+      url "https://github.com/pomerium/cli/releases/download/v0.29.1/pomerium-cli-linux-amd64.tar.gz"
+      sha256 "c8ef3670f18fe28c40872f9006ffb9d798428de7ca6d620a40a66cbebe21005c"
 
       def install
         bin.install "pomerium-cli"


### PR DESCRIPTION
Testing the ci workflows resulted in this erroneous update to the repo.

This reverts commit 5ecab9f8cd0c9c6bd6a89cfad4786724093693c3.